### PR TITLE
adapt to multi device screen by adding constraints

### DIFF
--- a/partytion-app/PartytionApp/Info.plist
+++ b/partytion-app/PartytionApp/Info.plist
@@ -31,8 +31,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/AnswerScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/AnswerScreen.storyboard
@@ -21,30 +21,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="Question" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yzB-Nz-xr0" userLabel="QuestionText">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Question" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yzB-Nz-xr0" userLabel="QuestionText">
                                 <rect key="frame" x="57" y="124" width="300" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" hint="質問文">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="128" id="Rzm-IO-veB"/>
+                                    <constraint firstAttribute="height" constant="128" id="rc9-ei-XJK"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="* / *" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sJl-gm-adv" userLabel="AnswererCount">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="* / *" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sJl-gm-adv" userLabel="AnswererCount">
                                 <rect key="frame" x="57" y="280" width="300" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" hint="質問文">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="48" id="RCT-yj-9XI"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1sW-G5-fAH" customClass="SSBouncyButton">
-                                <rect key="frame" x="57" y="592" width="300" height="100"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1sW-G5-fAH" customClass="SSBouncyButton">
+                                <rect key="frame" x="30" y="759" width="354" height="75"/>
                                 <color key="backgroundColor" red="0.93071061372756958" green="0.48199635744094849" blue="0.18812045454978943" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="75" id="LIJ-CZ-Qjh"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="40"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="No">
@@ -55,10 +62,27 @@
                                     <action selector="noButtonTapped:" destination="iaT-Wt-l2e" eventType="touchUpInside" id="e2w-xj-v7g"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MSQ-LK-vkm" customClass="SSBouncyButton">
-                                <rect key="frame" x="57" y="415" width="300" height="100"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" progress="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="Sc1-3J-R1V">
+                                <rect key="frame" x="57" y="348" width="300" height="2.5"/>
+                                <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" notEnabled="YES" updatesFrequently="YES"/>
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
+                                <rect key="contentStretch" x="0.0" y="1" width="1" height="1"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="300" id="csb-nv-Fqq"/>
+                                </constraints>
+                                <color key="progressTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </progressView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MSQ-LK-vkm" customClass="SSBouncyButton">
+                                <rect key="frame" x="30" y="647" width="354" height="75"/>
                                 <color key="backgroundColor" red="0.97555051810777205" green="0.68998797484583685" blue="0.16748606202707006" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="75" id="VYf-dP-3ZK"/>
+                                    <constraint firstAttribute="width" constant="354" id="jnG-Jo-64q"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="40"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Yes">
@@ -69,20 +93,26 @@
                                     <action selector="yesButtonTapped:" destination="iaT-Wt-l2e" eventType="touchUpInside" id="C1j-4S-qOu"/>
                                 </connections>
                             </button>
-                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" progressViewStyle="bar" progress="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="Sc1-3J-R1V">
-                                <rect key="frame" x="57" y="374.5" width="300" height="1.5"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" notEnabled="YES" updatesFrequently="YES"/>
-                                    <bool key="isElement" value="YES"/>
-                                </accessibility>
-                                <rect key="contentStretch" x="0.0" y="1" width="1" height="1"/>
-                                <color key="progressTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </progressView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.81470673520000003" blue="0.22343490890000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="lAj-7t-2UB" firstAttribute="trailing" secondItem="MSQ-LK-vkm" secondAttribute="trailing" constant="30" id="1E7-aK-JRz"/>
+                            <constraint firstItem="lAj-7t-2UB" firstAttribute="bottom" secondItem="1sW-G5-fAH" secondAttribute="bottom" constant="28" id="20R-x2-h7J"/>
+                            <constraint firstItem="lAj-7t-2UB" firstAttribute="trailing" secondItem="sJl-gm-adv" secondAttribute="trailing" constant="57" id="4Xj-W4-pyA"/>
+                            <constraint firstItem="Sc1-3J-R1V" firstAttribute="centerX" secondItem="iic-lK-cAX" secondAttribute="centerX" id="E3y-yG-Se1"/>
+                            <constraint firstItem="yzB-Nz-xr0" firstAttribute="centerX" secondItem="iic-lK-cAX" secondAttribute="centerX" id="Fq2-S4-ckE"/>
+                            <constraint firstItem="1sW-G5-fAH" firstAttribute="top" secondItem="MSQ-LK-vkm" secondAttribute="bottom" constant="37" id="GUW-26-es6"/>
+                            <constraint firstItem="sJl-gm-adv" firstAttribute="top" secondItem="yzB-Nz-xr0" secondAttribute="bottom" constant="28" id="Juh-C6-9Zx"/>
+                            <constraint firstItem="yzB-Nz-xr0" firstAttribute="top" secondItem="lAj-7t-2UB" secondAttribute="top" constant="80" id="QeV-hy-M4b"/>
+                            <constraint firstItem="lAj-7t-2UB" firstAttribute="trailing" secondItem="yzB-Nz-xr0" secondAttribute="trailing" constant="57" id="Vo1-ud-xEF"/>
+                            <constraint firstItem="sJl-gm-adv" firstAttribute="centerX" secondItem="iic-lK-cAX" secondAttribute="centerX" id="Zxf-8M-rVO"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Sc1-3J-R1V" secondAttribute="trailing" constant="37" id="bsB-fU-0kI"/>
+                            <constraint firstItem="1sW-G5-fAH" firstAttribute="centerX" secondItem="iic-lK-cAX" secondAttribute="centerX" id="fhN-0J-qD1"/>
+                            <constraint firstItem="1sW-G5-fAH" firstAttribute="centerX" secondItem="iic-lK-cAX" secondAttribute="centerX" id="fpe-fg-gWF"/>
+                            <constraint firstItem="Sc1-3J-R1V" firstAttribute="top" secondItem="sJl-gm-adv" secondAttribute="bottom" constant="20" id="nhl-l1-kJA"/>
+                            <constraint firstItem="MSQ-LK-vkm" firstAttribute="centerX" secondItem="iic-lK-cAX" secondAttribute="centerX" id="qWc-Kb-lU5"/>
+                            <constraint firstItem="lAj-7t-2UB" firstAttribute="trailing" secondItem="1sW-G5-fAH" secondAttribute="trailing" constant="30" id="smF-73-bs2"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="lAj-7t-2UB"/>
                     </view>
                     <connections>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/HowToScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/HowToScreen.storyboard
@@ -21,50 +21,54 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LdS-5z-z3d">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LdS-5z-z3d">
                                 <rect key="frame" x="0.0" y="44" width="414" height="658"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZpM-6X-TDF">
-                                        <rect key="frame" x="0.0" y="39" width="414" height="396"/>
-                                        <autoresizingMask key="autoresizingMask"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZpM-6X-TDF">
+                                        <rect key="frame" x="0.0" y="39" width="414" height="407"/>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="使い方" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hW-8d-GRb">
-                                        <rect key="frame" x="143" y="443" width="128" height="40"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="使い方" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hW-8d-GRb">
+                                        <rect key="frame" x="20" y="454" width="374" height="29"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="29" id="oAF-ce-EG3"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="text" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dod-5x-7Ht">
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="text" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dod-5x-7Ht">
                                         <rect key="frame" x="20" y="491" width="374" height="147"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="147" id="kOy-op-W3s"/>
+                                        </constraints>
                                         <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="20"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="ZpM-6X-TDF" firstAttribute="leading" secondItem="LdS-5z-z3d" secondAttribute="leading" id="3Zc-Fd-u8x"/>
+                                    <constraint firstAttribute="trailing" secondItem="ZpM-6X-TDF" secondAttribute="trailing" id="81C-0u-aCV"/>
+                                    <constraint firstItem="dod-5x-7Ht" firstAttribute="top" secondItem="4hW-8d-GRb" secondAttribute="bottom" constant="8" id="AVn-9m-abs"/>
+                                    <constraint firstItem="ZpM-6X-TDF" firstAttribute="top" secondItem="LdS-5z-z3d" secondAttribute="top" constant="39" id="Bd6-1o-TGM"/>
+                                    <constraint firstAttribute="bottom" secondItem="dod-5x-7Ht" secondAttribute="bottom" constant="20" id="IOo-k3-NhW"/>
+                                    <constraint firstItem="4hW-8d-GRb" firstAttribute="leading" secondItem="LdS-5z-z3d" secondAttribute="leading" constant="20" id="IwN-7H-EpL"/>
+                                    <constraint firstItem="4hW-8d-GRb" firstAttribute="top" secondItem="ZpM-6X-TDF" secondAttribute="bottom" constant="8" id="JcD-ge-G3K"/>
+                                    <constraint firstAttribute="trailing" secondItem="dod-5x-7Ht" secondAttribute="trailing" constant="20" id="XI8-Ow-uXr"/>
+                                    <constraint firstItem="4hW-8d-GRb" firstAttribute="top" secondItem="ZpM-6X-TDF" secondAttribute="bottom" constant="8" id="bff-Jr-Sfm"/>
+                                    <constraint firstItem="dod-5x-7Ht" firstAttribute="leading" secondItem="LdS-5z-z3d" secondAttribute="leading" constant="20" id="i6c-k7-MBl"/>
+                                    <constraint firstAttribute="trailing" secondItem="4hW-8d-GRb" secondAttribute="trailing" constant="20" id="vhE-9Q-vhK"/>
+                                </constraints>
                             </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mmX-4v-dDH">
-                                <rect key="frame" x="0.0" y="703" width="414" height="159"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmX-4v-dDH">
+                                <rect key="frame" x="0.0" y="708" width="414" height="159"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sQn-co-NkZ" userLabel="Back Button" customClass="SSBouncyButton">
-                                        <rect key="frame" x="79" y="114" width="256" height="45"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" name="Arial-BoldItalicMT" family="Arial" pointSize="24"/>
-                                        <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <state key="normal" title="Skip">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="skipButtonTapped:" destination="0w8-DB-zeN" eventType="touchUpInside" id="827-d4-1I7"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0J5-vh-Mgg" userLabel="Next Button" customClass="SSBouncyButton">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0J5-vh-Mgg" userLabel="Next Button" customClass="SSBouncyButton">
                                         <rect key="frame" x="79" y="45" width="256" height="48"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="0.91386010360000003" green="0.64860062129999996" blue="0.1609713086" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="48" id="cjQ-bT-QkH"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="Arial-BoldItalicMT" family="Arial" pointSize="24"/>
                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Next">
@@ -74,14 +78,56 @@
                                             <action selector="nextButtonTapped:" destination="0w8-DB-zeN" eventType="touchUpInside" id="TAq-JO-aTl"/>
                                         </connections>
                                     </button>
-                                    <pageControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="l5L-fH-Yph">
+                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="l5L-fH-Yph">
                                         <rect key="frame" x="175" y="0.0" width="64" height="37"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="37" id="M7V-5m-JfY"/>
+                                        </constraints>
                                     </pageControl>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sQn-co-NkZ" userLabel="Back Button" customClass="SSBouncyButton">
+                                        <rect key="frame" x="79" y="101" width="256" height="45"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="45" id="XOW-FV-ete"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="Arial-BoldItalicMT" family="Arial" pointSize="24"/>
+                                        <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Skip">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="skipButtonTapped:" destination="0w8-DB-zeN" eventType="touchUpInside" id="827-d4-1I7"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="0J5-vh-Mgg" firstAttribute="centerX" secondItem="mmX-4v-dDH" secondAttribute="centerX" id="02b-am-Gq1"/>
+                                    <constraint firstAttribute="trailing" secondItem="l5L-fH-Yph" secondAttribute="trailing" constant="175" id="1bp-95-v3h"/>
+                                    <constraint firstAttribute="height" constant="159" id="4zR-HR-peD"/>
+                                    <constraint firstItem="l5L-fH-Yph" firstAttribute="leading" secondItem="mmX-4v-dDH" secondAttribute="leading" constant="175" id="IQh-D0-Dpm"/>
+                                    <constraint firstItem="l5L-fH-Yph" firstAttribute="top" secondItem="mmX-4v-dDH" secondAttribute="top" id="Loo-Gl-OpX"/>
+                                    <constraint firstItem="sQn-co-NkZ" firstAttribute="top" secondItem="0J5-vh-Mgg" secondAttribute="bottom" constant="8" id="a4B-Zx-R3j"/>
+                                    <constraint firstAttribute="trailing" secondItem="0J5-vh-Mgg" secondAttribute="trailing" constant="79" id="cEV-TN-TJL"/>
+                                    <constraint firstAttribute="trailing" secondItem="sQn-co-NkZ" secondAttribute="trailing" constant="79" id="jYn-L7-lZE"/>
+                                    <constraint firstItem="0J5-vh-Mgg" firstAttribute="leading" secondItem="mmX-4v-dDH" secondAttribute="leading" constant="79" id="nvS-mv-cbh"/>
+                                    <constraint firstItem="0J5-vh-Mgg" firstAttribute="top" secondItem="l5L-fH-Yph" secondAttribute="bottom" constant="8" id="qWD-zq-pri"/>
+                                    <constraint firstItem="sQn-co-NkZ" firstAttribute="leading" secondItem="mmX-4v-dDH" secondAttribute="leading" constant="79" id="tGq-JH-SSZ"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.81470673520000003" blue="0.22343490890000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="mmX-4v-dDH" firstAttribute="leading" secondItem="9gN-WF-KKI" secondAttribute="leading" id="2kk-GZ-to0"/>
+                            <constraint firstItem="mmX-4v-dDH" firstAttribute="top" secondItem="LdS-5z-z3d" secondAttribute="bottom" constant="6" id="7V2-P2-uE0"/>
+                            <constraint firstItem="LdS-5z-z3d" firstAttribute="top" secondItem="9gN-WF-KKI" secondAttribute="top" id="CAx-iU-t8p"/>
+                            <constraint firstItem="mmX-4v-dDH" firstAttribute="centerX" secondItem="Ova-X9-RCP" secondAttribute="centerX" id="Op6-6E-3jU"/>
+                            <constraint firstItem="mmX-4v-dDH" firstAttribute="trailing" secondItem="9gN-WF-KKI" secondAttribute="trailing" id="OqF-21-ZFy"/>
+                            <constraint firstItem="LdS-5z-z3d" firstAttribute="centerX" secondItem="Ova-X9-RCP" secondAttribute="centerX" id="PWp-KK-6Jz"/>
+                            <constraint firstItem="LdS-5z-z3d" firstAttribute="leading" secondItem="9gN-WF-KKI" secondAttribute="leading" id="Vz1-Ed-KDK"/>
+                            <constraint firstItem="LdS-5z-z3d" firstAttribute="trailing" secondItem="9gN-WF-KKI" secondAttribute="trailing" id="X0j-SV-xhh"/>
+                            <constraint firstItem="mmX-4v-dDH" firstAttribute="centerX" secondItem="Ova-X9-RCP" secondAttribute="centerX" id="c5v-Uf-wfC"/>
+                            <constraint firstItem="mmX-4v-dDH" firstAttribute="top" secondItem="LdS-5z-z3d" secondAttribute="bottom" constant="6" id="gkR-xS-DsM"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="mmX-4v-dDH" secondAttribute="bottom" constant="-5" id="wBS-fJ-fFb"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="9gN-WF-KKI"/>
                     </view>
                     <connections>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/HowToScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/HowToScreen.storyboard
@@ -79,7 +79,7 @@
                                         </connections>
                                     </button>
                                     <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="l5L-fH-Yph">
-                                        <rect key="frame" x="175" y="0.0" width="64" height="37"/>
+                                        <rect key="frame" x="187.5" y="0.0" width="39" height="37"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="37" id="M7V-5m-JfY"/>
                                         </constraints>
@@ -101,9 +101,8 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="0J5-vh-Mgg" firstAttribute="centerX" secondItem="mmX-4v-dDH" secondAttribute="centerX" id="02b-am-Gq1"/>
-                                    <constraint firstAttribute="trailing" secondItem="l5L-fH-Yph" secondAttribute="trailing" constant="175" id="1bp-95-v3h"/>
                                     <constraint firstAttribute="height" constant="159" id="4zR-HR-peD"/>
-                                    <constraint firstItem="l5L-fH-Yph" firstAttribute="leading" secondItem="mmX-4v-dDH" secondAttribute="leading" constant="175" id="IQh-D0-Dpm"/>
+                                    <constraint firstItem="l5L-fH-Yph" firstAttribute="centerX" secondItem="mmX-4v-dDH" secondAttribute="centerX" id="EWN-Bl-ujp"/>
                                     <constraint firstItem="l5L-fH-Yph" firstAttribute="top" secondItem="mmX-4v-dDH" secondAttribute="top" id="Loo-Gl-OpX"/>
                                     <constraint firstItem="sQn-co-NkZ" firstAttribute="top" secondItem="0J5-vh-Mgg" secondAttribute="bottom" constant="8" id="a4B-Zx-R3j"/>
                                     <constraint firstAttribute="trailing" secondItem="0J5-vh-Mgg" secondAttribute="trailing" constant="79" id="cEV-TN-TJL"/>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/PlayerScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/PlayerScreen.storyboard
@@ -21,10 +21,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Svt-bd-40v" customClass="SSBouncyButton">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Svt-bd-40v" customClass="SSBouncyButton">
                                 <rect key="frame" x="313" y="455" width="67" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" red="0.91386010360000003" green="0.64860062129999996" blue="0.1609713086" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="46" id="Uev-BJ-80e"/>
+                                    <constraint firstAttribute="width" constant="67" id="oYS-Ge-aff"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Next">
@@ -35,23 +38,24 @@
                                     <action selector="nextButtonTapped:" destination="5u8-FC-htc" eventType="touchUpInside" id="s73-SH-Ser"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Player Screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cBV-Gb-Lrp">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Player Screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cBV-Gb-Lrp">
                                 <rect key="frame" x="118" y="222" width="178" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="34" id="ewt-v4-YOp"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="28"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HSc-r6-pYp">
-                                <rect key="frame" x="35" y="317" width="345" height="81"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HSc-r6-pYp">
+                                <rect key="frame" x="34" y="317" width="346" height="81"/>
                                 <subviews>
                                     <view autoresizesSubviews="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VNu-KR-bkk" customClass="GMStepper" customModule="GMStepper">
-                                        <rect key="frame" x="0.0" y="0.0" width="345" height="81"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="346" height="81"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <accessibility key="accessibilityConfiguration">
@@ -80,9 +84,21 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="81" id="CTf-iv-wpb"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.81470673522221437" blue="0.22343490893666618" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="cJq-c3-4tj" firstAttribute="trailing" secondItem="Svt-bd-40v" secondAttribute="trailing" constant="34" id="60N-Eo-WVf"/>
+                            <constraint firstItem="cBV-Gb-Lrp" firstAttribute="centerX" secondItem="KVe-BP-WLi" secondAttribute="centerX" id="8oW-l5-07c"/>
+                            <constraint firstItem="Svt-bd-40v" firstAttribute="top" secondItem="HSc-r6-pYp" secondAttribute="bottom" constant="57" id="9L7-Co-eMW"/>
+                            <constraint firstItem="HSc-r6-pYp" firstAttribute="top" secondItem="cBV-Gb-Lrp" secondAttribute="bottom" constant="61" id="MiM-Yf-Ue1"/>
+                            <constraint firstItem="cBV-Gb-Lrp" firstAttribute="top" secondItem="cJq-c3-4tj" secondAttribute="top" constant="178" id="l0a-Wb-Tpk"/>
+                            <constraint firstItem="HSc-r6-pYp" firstAttribute="trailing" secondItem="Svt-bd-40v" secondAttribute="trailing" id="nSH-Wh-14m"/>
+                            <constraint firstItem="HSc-r6-pYp" firstAttribute="centerX" secondItem="KVe-BP-WLi" secondAttribute="centerX" id="wNB-mf-Rk9"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="cJq-c3-4tj"/>
                     </view>
                     <connections>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/QuestionScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/QuestionScreen.storyboard
@@ -21,40 +21,59 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Sample Theme" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvO-e9-MWh">
-                                <rect key="frame" x="31" y="134" width="352" height="81"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sample Theme" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvO-e9-MWh">
+                                <rect key="frame" x="114" y="134" width="186.5" height="81"/>
                                 <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="81" id="Zkn-tz-PYC"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="28"/>
                                 <color key="textColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="op4-qn-cf1" userLabel="Question Text" customClass="PlaceHolderTextView" customModule="PartytionApp" customModuleProvider="target">
-                                <rect key="frame" x="31" y="317" width="352" height="204"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="op4-qn-cf1" userLabel="Question Text" customClass="PlaceHolderTextView" customModule="PartytionApp" customModuleProvider="target">
+                                <rect key="frame" x="31" y="317" width="352" height="444"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="になるような質問を 考えましょう！" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oZt-3p-otE">
-                                <rect key="frame" x="31" y="225" width="352" height="63"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="になるような質問を 考えましょう！" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oZt-3p-otE">
+                                <rect key="frame" x="99" y="225" width="216" height="63"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="63" id="NjL-Ah-YVQ"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qda-tg-J7E" userLabel="Next Button" customClass="SSBouncyButton">
-                                <rect key="frame" x="316" y="685" width="67" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ジャンル" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8k1-eY-r9P">
+                                <rect key="frame" x="151" y="93" width="112" height="34"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                                    <bool key="isElement" value="NO"/>
+                                </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="34" id="a1N-qF-fPT"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="28"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qda-tg-J7E" userLabel="Next Button" customClass="SSBouncyButton">
+                                <rect key="frame" x="316" y="791" width="67" height="46"/>
                                 <color key="backgroundColor" red="0.91386010360000003" green="0.64860062129999996" blue="0.1609713086" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="67" id="hfM-NN-qhl"/>
+                                    <constraint firstAttribute="height" constant="46" id="hx0-o9-HbE"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="24"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Next">
@@ -65,19 +84,23 @@
                                     <action selector="nextButtonTapped:" destination="I2d-Yy-qIT" eventType="touchUpInside" id="C98-bj-3VW"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="ジャンル" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8k1-eY-r9P">
-                                <rect key="frame" x="151" y="93" width="112" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                                    <bool key="isElement" value="NO"/>
-                                </accessibility>
-                                <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="28"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.81470673520000003" blue="0.22343490890000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="gIT-vG-IQh" firstAttribute="trailing" secondItem="qda-tg-J7E" secondAttribute="trailing" constant="31" id="9hT-pr-yg2"/>
+                            <constraint firstItem="qda-tg-J7E" firstAttribute="top" secondItem="op4-qn-cf1" secondAttribute="bottom" constant="30" id="BI6-v8-k5z"/>
+                            <constraint firstItem="dvO-e9-MWh" firstAttribute="top" secondItem="8k1-eY-r9P" secondAttribute="bottom" constant="7" id="FIo-VE-BE2"/>
+                            <constraint firstItem="dvO-e9-MWh" firstAttribute="centerX" secondItem="FGD-Ah-zgA" secondAttribute="centerX" id="Gae-mf-S5O"/>
+                            <constraint firstItem="oZt-3p-otE" firstAttribute="centerX" secondItem="FGD-Ah-zgA" secondAttribute="centerX" id="XL3-fj-pAw"/>
+                            <constraint firstItem="8k1-eY-r9P" firstAttribute="centerX" secondItem="FGD-Ah-zgA" secondAttribute="centerX" id="Y8U-I5-15j"/>
+                            <constraint firstItem="op4-qn-cf1" firstAttribute="top" secondItem="oZt-3p-otE" secondAttribute="bottom" constant="29" id="d4e-QF-pwY"/>
+                            <constraint firstItem="oZt-3p-otE" firstAttribute="top" secondItem="dvO-e9-MWh" secondAttribute="bottom" constant="10" id="g6L-8w-vs8"/>
+                            <constraint firstItem="gIT-vG-IQh" firstAttribute="bottom" secondItem="op4-qn-cf1" secondAttribute="bottom" constant="101" id="heU-1d-LXB"/>
+                            <constraint firstItem="op4-qn-cf1" firstAttribute="centerX" secondItem="FGD-Ah-zgA" secondAttribute="centerX" id="iLC-b0-XkM"/>
+                            <constraint firstItem="gIT-vG-IQh" firstAttribute="trailing" secondItem="op4-qn-cf1" secondAttribute="trailing" constant="31" id="lqc-W9-tIG"/>
+                            <constraint firstItem="op4-qn-cf1" firstAttribute="leading" secondItem="gIT-vG-IQh" secondAttribute="leading" constant="31" id="tSj-G4-Ijh"/>
+                            <constraint firstItem="8k1-eY-r9P" firstAttribute="top" secondItem="gIT-vG-IQh" secondAttribute="top" constant="49" id="ui0-Ox-8nA"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="gIT-vG-IQh"/>
                     </view>
                     <connections>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/ResultScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/ResultScreen.storyboard
@@ -24,53 +24,62 @@
                             <view autoresizesSubviews="NO" clipsSubviews="YES" contentMode="top" semanticContentAttribute="playback" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OLP-eJ-usd" userLabel="Animation Panel" customClass="AnimationView">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="結果発表" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jpl-IT-ake">
-                                        <rect key="frame" x="147" y="68" width="120" height="36"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                                            <bool key="isElement" value="NO"/>
-                                        </accessibility>
-                                        <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="30"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="質問" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9GN-Yx-1mg">
-                                        <rect key="frame" x="181" y="112" width="53" height="32"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                                            <bool key="isElement" value="NO"/>
-                                        </accessibility>
-                                        <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="26"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
                                 <accessibility key="accessibilityConfiguration" identifier="SplashAnimationView">
                                     <accessibilityTraits key="traits" none="YES"/>
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
                             </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ICH-Cg-5HQ" customClass="PieChartView" customModule="Charts">
-                                <rect key="frame" x="20" y="410" width="374" height="221"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ICH-Cg-5HQ" customClass="PieChartView" customModule="Charts">
+                                <rect key="frame" x="20" y="621" width="374" height="221"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="ICH-Cg-5HQ" secondAttribute="height" multiplier="22:13" id="nwB-Nn-aYU"/>
+                                </constraints>
                             </view>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="質問" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1AG-GU-Ejm">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="質問" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9GN-Yx-1mg">
+                                <rect key="frame" x="20" y="100" width="374" height="32"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                                    <bool key="isElement" value="NO"/>
+                                </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="32" id="d3R-zN-9Vu"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="26"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="結果発表" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jpl-IT-ake">
+                                <rect key="frame" x="20" y="50" width="374" height="36"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
+                                    <bool key="isElement" value="NO"/>
+                                </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="36" id="WHm-br-1Mi"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="質問" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1AG-GU-Ejm">
                                 <rect key="frame" x="20" y="173" width="374" height="113"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" hint="Question Text" label="質問文">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="113" id="LQH-RQ-und"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="17"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bWu-24-Eyj" customClass="SSBouncyButton">
-                                <rect key="frame" x="274" y="340" width="120" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bWu-24-Eyj" customClass="SSBouncyButton">
+                                <rect key="frame" x="274" y="550" width="120" height="36"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="36" id="Owh-Y9-CpQ"/>
+                                    <constraint firstAttribute="width" constant="120" id="Wr8-b2-zNV"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="20"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="もう一度遊ぶ">
@@ -80,18 +89,39 @@
                                     <action selector="replyButtonTapped:" destination="Au2-6O-ED5" eventType="touchUpInside" id="JOz-Nj-6jj"/>
                                 </connections>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" text="n vs m" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6tg-6Z-HAf" userLabel="Partition Text">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="n vs m" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6tg-6Z-HAf" userLabel="Partition Text">
                                 <rect key="frame" x="20" y="285" width="374" height="44"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" hint="Question Text" label="質問文">
                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="fdH-TC-2VE"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Oshidashi-M-Gothic-Regular" family="Oshidashi-M-Gothic" pointSize="17"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.68190638699999995" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="jpl-IT-ake" firstAttribute="top" secondItem="Uyi-y5-TXg" secondAttribute="top" constant="6" id="20V-DE-UiO"/>
+                            <constraint firstItem="ICH-Cg-5HQ" firstAttribute="top" secondItem="bWu-24-Eyj" secondAttribute="bottom" constant="35" id="24X-Zx-bM5"/>
+                            <constraint firstItem="6tg-6Z-HAf" firstAttribute="leading" secondItem="Uyi-y5-TXg" secondAttribute="leading" constant="20" id="79e-Sv-oYe"/>
+                            <constraint firstItem="ICH-Cg-5HQ" firstAttribute="leading" secondItem="Uyi-y5-TXg" secondAttribute="leading" constant="20" id="Ae0-2x-iBb"/>
+                            <constraint firstItem="9GN-Yx-1mg" firstAttribute="leading" secondItem="Uyi-y5-TXg" secondAttribute="leading" constant="20" id="Imc-gk-e62"/>
+                            <constraint firstItem="6tg-6Z-HAf" firstAttribute="top" secondItem="9GN-Yx-1mg" secondAttribute="bottom" constant="153" id="JeR-bt-fMj"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="trailing" secondItem="6tg-6Z-HAf" secondAttribute="trailing" constant="20" id="MDR-M0-Nw0"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="bottom" secondItem="ICH-Cg-5HQ" secondAttribute="bottom" constant="20" id="NqE-ni-MZC"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="trailing" secondItem="9GN-Yx-1mg" secondAttribute="trailing" constant="20" id="P1f-Oe-qep"/>
+                            <constraint firstItem="1AG-GU-Ejm" firstAttribute="top" secondItem="9GN-Yx-1mg" secondAttribute="bottom" constant="41" id="bL3-zj-SJm"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="trailing" secondItem="bWu-24-Eyj" secondAttribute="trailing" constant="20" id="dgr-CS-t3V"/>
+                            <constraint firstItem="9GN-Yx-1mg" firstAttribute="top" secondItem="jpl-IT-ake" secondAttribute="bottom" constant="14" id="e1r-38-BXE"/>
+                            <constraint firstItem="jpl-IT-ake" firstAttribute="leading" secondItem="Uyi-y5-TXg" secondAttribute="leading" constant="20" id="kse-Dz-Ctt"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="trailing" secondItem="1AG-GU-Ejm" secondAttribute="trailing" constant="20" id="pIb-9M-9ki"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="trailing" secondItem="ICH-Cg-5HQ" secondAttribute="trailing" constant="20" id="qME-pc-8sn"/>
+                            <constraint firstItem="1AG-GU-Ejm" firstAttribute="leading" secondItem="Uyi-y5-TXg" secondAttribute="leading" constant="20" id="wwo-7f-1w1"/>
+                            <constraint firstItem="Uyi-y5-TXg" firstAttribute="trailing" secondItem="jpl-IT-ake" secondAttribute="trailing" constant="20" id="zgX-aE-s6j"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Uyi-y5-TXg"/>
                     </view>
                     <connections>

--- a/partytion-app/PartytionApp/Presentation/View/Storyboards/SplashScreen.storyboard
+++ b/partytion-app/PartytionApp/Presentation/View/Storyboards/SplashScreen.storyboard
@@ -16,9 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view autoresizesSubviews="NO" clipsSubviews="YES" contentMode="top" semanticContentAttribute="playback" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lt2-b4-Z3H" customClass="AnimationView">
+                            <view autoresizesSubviews="NO" clipsSubviews="YES" contentMode="top" semanticContentAttribute="playback" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lt2-b4-Z3H" customClass="AnimationView">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" identifier="SplashAnimationView">
                                     <accessibilityTraits key="traits" none="YES"/>
                                     <bool key="isElement" value="YES"/>
@@ -26,6 +25,12 @@
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="lt2-b4-Z3H" firstAttribute="trailing" secondItem="yyj-Va-tyb" secondAttribute="trailing" id="5pM-TU-4st"/>
+                            <constraint firstAttribute="bottom" secondItem="lt2-b4-Z3H" secondAttribute="bottom" id="Lo7-Jd-S0O"/>
+                            <constraint firstItem="lt2-b4-Z3H" firstAttribute="top" secondItem="ill-eh-6U5" secondAttribute="top" id="WpA-tS-h3c"/>
+                            <constraint firstItem="lt2-b4-Z3H" firstAttribute="leading" secondItem="yyj-Va-tyb" secondAttribute="leading" id="sbu-cG-2kn"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="yyj-Va-tyb"/>
                     </view>
                     <connections>


### PR DESCRIPTION
## クロスプラットフォーム対応
下記画面サイズにてすべてのUIコンポーネントが画面内に配置するよう対応しました。([#16の役割分担部分](https://github.com/naruhiyo/partytion/issues/16#issuecomment-548340119))
- 6.5 インチ
- 5.8 インチ
- 5.5 インチ
- 4.7 インチ
- 4 インチ

[画面サイズ参考](https://help.apple.com/app-store-connect/#/devd274dd925)